### PR TITLE
홈화면 동네설정 필터 기능 추가

### DIFF
--- a/frontend/src/api/member.ts
+++ b/frontend/src/api/member.ts
@@ -43,3 +43,37 @@ export const getSeller = async (
   });
   return res;
 };
+
+export const patchMembersLocation = async (
+  token: string | null,
+  locations: string[],
+) => {
+  const res = await axiosInstanceWithBearer.patch(
+    `/api/members/locations`,
+    locations,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+
+  return res;
+};
+
+export const patchMainLocation = async (
+  token: string | null,
+  index: number,
+) => {
+  const res = await axiosInstanceWithBearer.patch(
+    `/api/members/mainLocation`,
+    index,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+
+  return res;
+};

--- a/frontend/src/api/product.ts
+++ b/frontend/src/api/product.ts
@@ -1,7 +1,11 @@
 import { axiosInstanceWithoutBearer, axiosInstanceWithBearer } from './axios';
 
-export const getProducts = async () => {
-  const res = await axiosInstanceWithoutBearer.get(`/api/products?`);
+// http://localhost:8080/api/products?locationId=1&categoryId=1&page=20 물품 데이터 요청 예시
+
+export const getProducts = async (locationId: string | undefined) => {
+  const res = await axiosInstanceWithoutBearer.get(
+    `/api/products?locationId=${locationId}`,
+  );
   return res;
 };
 

--- a/frontend/src/components/DetailTapBar/index.tsx
+++ b/frontend/src/components/DetailTapBar/index.tsx
@@ -64,11 +64,7 @@ const DetailTapBar = ({ price, curProductsId }: DetailTapBarProps) => {
   // 방으로 이동
   const enterChatRoom = (roomId: string) => {
     sessionStorage.setItem('curRoomId', roomId);
-    if (curProductsId) {
-      sessionStorage.setItem('curProductsId', curProductsId);
-    } else {
-      sessionStorage.removeItem('curProductsId');
-    }
+    if (curProductsId) sessionStorage.setItem('curProductsId', curProductsId);
     navigate(`${CHATROOM}/${roomId}`);
   };
 

--- a/frontend/src/components/Dropdown/DropdownPanel/index.tsx
+++ b/frontend/src/components/Dropdown/DropdownPanel/index.tsx
@@ -2,17 +2,27 @@ import * as S from './styles';
 
 interface DropdownPanelProps {
   option: string;
-  onClick: (option: string) => void;
+  onClickNonOption?: () => Promise<void> | undefined;
+  onClickOption?: () => void | undefined;
   isLastPanel?: boolean;
 }
 
 const DropdownPanel = ({
   option,
-  onClick,
+  onClickNonOption,
+  onClickOption,
   isLastPanel,
 }: DropdownPanelProps) => {
+  const handleClick = () => {
+    if (onClickNonOption) {
+      onClickNonOption();
+    } else if (onClickOption) {
+      onClickOption();
+    }
+  };
+
   return (
-    <S.DropdownPanel onClick={() => onClick(option)} isLastPanel={isLastPanel}>
+    <S.DropdownPanel onClick={handleClick} isLastPanel={isLastPanel}>
       <S.OptionTitle isLastPanel={isLastPanel}>{option}</S.OptionTitle>
     </S.DropdownPanel>
   );

--- a/frontend/src/components/Dropdown/index.tsx
+++ b/frontend/src/components/Dropdown/index.tsx
@@ -5,13 +5,15 @@ import * as S from './styles';
 import DropdownPanel from './DropdownPanel';
 import Icon from '../Icon';
 
-interface LocationData {
+interface Location {
+  locationId: string;
   locationDetails: string;
   locationShortening: string;
+  isMainLocation: boolean;
 }
 
 interface DropdownProps {
-  options: LocationData[];
+  options: Location[];
   isSetLocationOption: boolean;
   isReverse: boolean;
 }

--- a/frontend/src/components/Dropdown/index.tsx
+++ b/frontend/src/components/Dropdown/index.tsx
@@ -4,6 +4,8 @@ import * as S from './styles';
 
 import DropdownPanel from './DropdownPanel';
 import Icon from '../Icon';
+import { ACCESS_TOKEN } from '../../constants/login';
+import { patchMainLocation } from '../../api/member';
 
 interface Location {
   locationId: string;
@@ -16,24 +18,34 @@ interface DropdownProps {
   options: Location[];
   isSetLocationOption: boolean;
   isReverse: boolean;
+  fetchUserData?: () => Promise<void> | undefined;
 }
 
 const Dropdown = ({
   options,
   isSetLocationOption,
   isReverse,
+  fetchUserData,
 }: DropdownProps) => {
-  // TODO : 동네설정 state를 홈에서 받아와서 필터 해주기
-  const [selectedOption, setSelectedOption] = useState<string>(
-    options[0]?.locationShortening,
-  );
+  const accessToken = localStorage.getItem(ACCESS_TOKEN);
+  console.log(options);
+
+  const mainLocation =
+    options.find((locationIndo) => locationIndo.isMainLocation)
+      ?.locationShortening || undefined;
 
   // TODO : 다른 곳 클릭하면 드롭다운 닫기 옵션 추가하기
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleOptionClick = (option: string) => {
-    setSelectedOption(option);
-    setIsOpen(false);
+  const handleFetchUserData = async (index: number) => {
+    console.log(index);
+
+    // TODO : 유저 정보 변경하는 API 필요
+    await patchMainLocation(accessToken, index);
+
+    if (fetchUserData) {
+      fetchUserData();
+    }
   };
 
   const toggleDropdown = () => {
@@ -50,7 +62,7 @@ const Dropdown = ({
     <S.DropdownContainer>
       <S.DropdownWrapper />
       <S.DropdownHeader onClick={toggleDropdown}>
-        <S.SelectedOption>{selectedOption}</S.SelectedOption>
+        <S.SelectedOption>{mainLocation}</S.SelectedOption>
         {isReverse === false && <Icon name={'chevronDown'} width="17" />}
       </S.DropdownHeader>
       {isOpen && (
@@ -59,14 +71,18 @@ const Dropdown = ({
             <DropdownPanel
               key={index}
               option={option.locationShortening}
-              onClick={handleOptionClick}
+              onClickNonOption={
+                options.length === 1
+                  ? undefined
+                  : () => handleFetchUserData(index)
+              }
             />
           ))}
           {isSetLocationOption && (
             <DropdownPanel
               key={2}
               option={'내 동네 변경하기'}
-              onClick={handleChangeOptionClick}
+              onClickOption={handleChangeOptionClick}
               isLastPanel={true}
             />
           )}

--- a/frontend/src/components/NavBarHome/index.tsx
+++ b/frontend/src/components/NavBarHome/index.tsx
@@ -3,21 +3,25 @@ import * as S from './styles';
 import Dropdown from '../Dropdown';
 import Icon from '../Icon';
 
-interface LocationData {
+interface Location {
+  locationId: string;
   locationDetails: string;
   locationShortening: string;
+  isMainLocation: boolean;
 }
 
 interface NavBarHomeProps {
   type: string;
   iconOnClick?: () => void;
-  userLocationDatas: LocationData[];
+  userLocationDatas: Location[];
+  isUserLogin: boolean;
 }
 
 const NavBarHome = ({
   type,
   iconOnClick,
   userLocationDatas,
+  isUserLogin,
 }: NavBarHomeProps) => {
   return (
     <S.NavBarContainer type={type}>
@@ -25,7 +29,7 @@ const NavBarHome = ({
         <S.ClinkElement>
           <Dropdown
             options={userLocationDatas}
-            isSetLocationOption={true}
+            isSetLocationOption={isUserLogin}
             isReverse={false}
           />
         </S.ClinkElement>

--- a/frontend/src/components/NavBarHome/index.tsx
+++ b/frontend/src/components/NavBarHome/index.tsx
@@ -15,6 +15,7 @@ interface NavBarHomeProps {
   iconOnClick?: () => void;
   userLocationDatas: Location[];
   isUserLogin: boolean;
+  fetchUserData: () => Promise<void> | undefined;
 }
 
 const NavBarHome = ({
@@ -22,6 +23,7 @@ const NavBarHome = ({
   iconOnClick,
   userLocationDatas,
   isUserLogin,
+  fetchUserData,
 }: NavBarHomeProps) => {
   return (
     <S.NavBarContainer type={type}>
@@ -31,6 +33,7 @@ const NavBarHome = ({
             options={userLocationDatas}
             isSetLocationOption={isUserLogin}
             isReverse={false}
+            fetchUserData={fetchUserData}
           />
         </S.ClinkElement>
         <S.ClinkElement>

--- a/frontend/src/constants/defaultValues.ts
+++ b/frontend/src/constants/defaultValues.ts
@@ -7,8 +7,8 @@ export const defaultLocation = [
   },
   {
     locationId: '12',
-    locationDetails: '서울특별시 강남구 역삼1동',
-    locationShortening: '역삼1동',
+    locationDetails: '서울특별시 강남구 삼성1동',
+    locationShortening: '삼성1동',
     isMainLocation: false,
   },
 ];

--- a/frontend/src/constants/defaultValues.ts
+++ b/frontend/src/constants/defaultValues.ts
@@ -1,0 +1,14 @@
+export const defaultLocation = [
+  {
+    locationId: '18',
+    locationDetails: '서울특별시 강남구 역삼1동',
+    locationShortening: '역삼1동',
+    isMainLocation: true,
+  },
+  {
+    locationId: '12',
+    locationDetails: '서울특별시 강남구 역삼1동',
+    locationShortening: '역삼1동',
+    isMainLocation: false,
+  },
+];

--- a/frontend/src/constants/defaultValues.ts
+++ b/frontend/src/constants/defaultValues.ts
@@ -3,12 +3,12 @@ export const defaultLocation = [
     locationId: '18',
     locationDetails: '서울특별시 강남구 역삼1동',
     locationShortening: '역삼1동',
-    isMainLocation: true,
+    isMainLocation: false,
   },
   {
     locationId: '12',
     locationDetails: '서울특별시 강남구 삼성1동',
     locationShortening: '삼성1동',
-    isMainLocation: false,
+    isMainLocation: true,
   },
 ];

--- a/frontend/src/pages/ChatRoom/index.tsx
+++ b/frontend/src/pages/ChatRoom/index.tsx
@@ -54,20 +54,22 @@ const ChatRoom = () => {
     checkChatDetails();
   }, [accessToken, curRoomId]);
 
-  // 소켓 통신
+  // 소켓 연결
   const connectHandler = () => {
-    // SockJS와 Stomp 클라이언트 생성
+    // SockJS 클라이언트 객체를 생성하고, 웹 소켓을 연결한다.
+    // ws-stomp는 서버의 Endpoint 경로로, 웹 소켓 통신을 위한 특정 경로를 의미한다.
     const socket = new SockJS(`${BASE_URL}/ws-stomp`);
 
-    // client.current 초기화 및 연결 수행
+    // SockJS 클라이언트 객체 socket를 STOMP 프로토콜로 오버랩하여 client.current에 할당
     client.current = Stomp.over(socket);
+    // 클라이언트 객체를 서버와 연결
     client.current.connect(
       {
         Authorization: 'Bearer ' + accessToken,
         'Content-Type': 'application/json',
       },
       () => {
-        // 연결 성공 시 해당 방을 구독하고 새로운 매시지를 수신
+        // 연결 성공 시 해당 방을 구독하면 서버로부터 새로운 매시지를 수신 한다.
         client.current?.subscribe(
           `/sub/chat/room/${curRoomId}`,
           (message) => {
@@ -77,7 +79,6 @@ const ChatRoom = () => {
                 ? [...prevHistory, JSON.parse(message.body)]
                 : null;
             });
-            // console.log(message.body);
           },
           {
             Authorization: 'Bearer ' + accessToken,

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import * as S from './styles';
@@ -47,7 +47,7 @@ const HomePage = () => {
   const [isUserLogin, setIsUserLogin] = useState<boolean>(true);
 
   // 사용자 정보에서 location 가져오기
-  const fetchUserData = async () => {
+  const fetchUserDataRef = useRef<() => Promise<void> | undefined>(async () => {
     const { data: userData } = await getMembers(accessToken);
     const userLocationDatas = userData?.data?.locationDatas || defaultLocation;
 
@@ -56,7 +56,9 @@ const HomePage = () => {
       : setIsUserLogin(true);
 
     setCurLocationDatas(userLocationDatas);
-  };
+  });
+
+  const fetchUserData = fetchUserDataRef.current;
 
   // location정보에서 locationID로 물품 리스트 가져오기
   const fetchProductsData = async () => {
@@ -100,6 +102,7 @@ const HomePage = () => {
         iconOnClick={handleIconClick}
         userLocationDatas={curLocationDatas}
         isUserLogin={isUserLogin}
+        fetchUserData={fetchUserData}
       />
       {!isResultEmpty ? (
         <div>

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -44,15 +44,21 @@ const HomePage = () => {
   const accessToken = localStorage.getItem(ACCESS_TOKEN);
   const [curLocationDatas, setCurLocationDatas] = useState<Location[]>([]);
   const [itemList, setItemList] = useState<Item[]>([]);
+  const [isUserLogin, setIsUserLogin] = useState<boolean>(true);
 
   // 사용자 정보에서 location 가져오기
   const fetchUserData = async () => {
     const { data: userData } = await getMembers(accessToken);
     const userLocationDatas = userData?.data?.locationDatas || defaultLocation;
+
+    userLocationDatas === defaultLocation
+      ? setIsUserLogin(false)
+      : setIsUserLogin(true);
+
     setCurLocationDatas(userLocationDatas);
   };
 
-  // locarion정보에서 locarionID로 물품 리스트 가져오기
+  // location정보에서 locationID로 물품 리스트 가져오기
   const fetchProductsData = async () => {
     console.log(curLocationDatas);
     const curLoactionId =
@@ -93,6 +99,7 @@ const HomePage = () => {
         type="medium"
         iconOnClick={handleIconClick}
         userLocationDatas={curLocationDatas}
+        isUserLogin={isUserLogin}
       />
       {!isResultEmpty ? (
         <div>


### PR DESCRIPTION
closed : #140 
- 사용자의 location 정보로 물품 리스트 요청하는 로직 추가
- 홈 화면 상단 바에서 동네 변경 시 변경된 동네로 물픔 리스트 요청하는 로직 추가
- 로그인이 안되 있으면 default 값18번 (역삼1동) location 정보로 물품 리스트 요청

@JeonHyoChang @cire0304 
- 유저정보 요청 API 응답 데이터에서 locationId, isMainLocation 정보 추가 필요
- isMainLocation을 수정하는 patch API 추가 필요