### PR TITLE
FEAT: 동네 선택 리스트 페이지 구현 #142

### DIFF
--- a/frontend/src/components/Dropdown/index.tsx
+++ b/frontend/src/components/Dropdown/index.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { ACCESS_TOKEN } from '../../constants/login';
 import { useAuthContext } from '../../context/Auth';
-import * as S from './styles';
+import { patchMembersLocation } from '../../api/member';
 
+import * as S from './styles';
 import DropdownPanel from './DropdownPanel';
 import Icon from '../Icon';
-import { ACCESS_TOKEN } from '../../constants/login';
-import { patchMembersLocation } from '../../api/member';
 import { LOCATION } from '../../constants/routeUrl';
 
 interface Location {

--- a/frontend/src/components/NavBarHome/index.tsx
+++ b/frontend/src/components/NavBarHome/index.tsx
@@ -1,5 +1,4 @@
 import * as S from './styles';
-
 import Dropdown from '../Dropdown';
 import Icon from '../Icon';
 

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -2,15 +2,15 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useAuthContext } from '../../context/Auth';
-import * as S from './styles';
+import { getProducts } from '../../api/product';
 
+import * as S from './styles';
 import NavBarHome from '../../components/NavBarHome';
 import SecondHandItem from '../../components/SecondHandItem';
 import ErrorPage from '../Error';
 import { CATEGORY, ITEM_DETAIL, SALES_ITEM } from '../../constants/routeUrl';
 import Button from '../../components/Button';
 import Icon from '../../components/Icon';
-import { getProducts } from '../../api/product';
 import { defaultLocation } from '../../constants/defaultValues';
 
 interface Location {
@@ -45,7 +45,6 @@ const HomePage = () => {
   const [curLocationData, setCurLocationData] = useState<Location[]>([]);
   const [itemList, setItemList] = useState<Item[]>([]);
 
-  // 사용자 정보에서 location 가져오기
   const fetchUserData = () => {
     const userLocationData =
       isLoggedIn === true ? userData.userInfo.locationDatas : defaultLocation;
@@ -53,7 +52,6 @@ const HomePage = () => {
     setCurLocationData(userLocationData);
   };
 
-  // location정보에서 locationID로 물품 리스트 가져오기
   const fetchProductsData = async () => {
     const curLoactionId =
       curLocationData.find((locationInfo) => locationInfo.mainLocationState)

--- a/frontend/src/pages/Location/index.tsx
+++ b/frontend/src/pages/Location/index.tsx
@@ -1,15 +1,15 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import * as S from './styles';
-
 import { useAuthContext } from '../../context/Auth';
+import { ACCESS_TOKEN } from '../../constants/login';
+import { patchMembersLocation } from '../../api/member';
+
+import * as S from './styles';
 import NavBarTitle from '../../components/NavBarTitle';
 import Button from '../../components/Button';
 import Icon from '../../components/Icon';
-import { patchMembersLocation } from '../../api/member';
-import { ACCESS_TOKEN } from '../../constants/login';
-import { HOME } from '../../constants/routeUrl';
-import { useState } from 'react';
+import { HOME, LOCATION_SET } from '../../constants/routeUrl';
 
 interface Location {
   locationId: number;
@@ -58,17 +58,8 @@ export const LocationPage = () => {
     setModalOpen(false);
   };
 
-  const handleAddLocation = async () => {
-    console.log('동네 추가');
-    /*
-    1. 동네 추가를 누르면 동네 선택 페이지로 넘어간다.
-    2. 선택된 동네를 가져와서 고객 정보 변경 요청을 보낸다.
-    */
-
-    // 동네 리스트 변경 요청 로직
-    const locationIdList = [18, 1];
-    await patchMembersLocation(accessToken, locationIdList);
-    handleUpdateUserInfo();
+  const handleAddClick = () => {
+    navigate(LOCATION_SET);
   };
 
   const handleOpenModal = (event: React.MouseEvent, location: Location) => {
@@ -134,14 +125,13 @@ export const LocationPage = () => {
               </Button>
             ))}
             {curLocationsData.length === 1 && (
-              <Button onClick={handleAddLocation} fullWidth>
+              <Button onClick={handleAddClick} fullWidth>
                 <Icon name="symbol" width="13" height="20" fill="black" />
                 <span>동네 추가</span>
               </Button>
             )}
           </S.BtnContainer>
         </S.LocationContainer>
-        <button onClick={handleAddLocation}>동네 변경 요청</button>
         {isModalOpen && (
           <S.ModalDim>
             <S.ModalContainer>

--- a/frontend/src/pages/LocationSet/index.tsx
+++ b/frontend/src/pages/LocationSet/index.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import * as S from './styles';
+import useAsync from '../../hooks/useAsync';
+import { useAuthContext } from '../../context/Auth';
+import { ACCESS_TOKEN } from '../../constants/login';
+import { getLocation } from '../../api/location';
+import { patchMembersLocation } from '../../api/member';
 
+import * as S from './styles';
 import NavBarTitle from '../../components/NavBarTitle';
 import { LOCATION } from '../../constants/routeUrl';
-import { getLocation } from '../../api/location';
-import useAsync from '../../hooks/useAsync';
 import { SearchBar } from '../../components/SearchBar';
 
 interface Location {
@@ -18,12 +21,33 @@ interface Location {
 
 export const LocationSetPage = () => {
   const navigate = useNavigate();
+  const accessToken = localStorage.getItem(ACCESS_TOKEN);
+  const loggedInUserDate = useAuthContext();
+  const curLocationsData = loggedInUserDate.userInfo.locationDatas;
+  const { handleUpdateUserInfo } = useAuthContext();
 
   const { data } = useAsync(getLocation);
   const locationList = data?.data;
 
   const [searchTerm, setSearchTerm] = useState('');
   const [searchResults, setSearchResults] = useState<Location[]>([]);
+
+  const handleAddLocation = async (event: React.MouseEvent<HTMLElement>) => {
+    const targetElement = event.target as Element;
+    const closestLiElement = targetElement.closest('li');
+
+    if (closestLiElement) {
+      const clickedLocationId = Number(targetElement.getAttribute('data-key'));
+      const locationIdList = [
+        ...curLocationsData.map((location) => location.locationId),
+        clickedLocationId,
+      ];
+
+      await patchMembersLocation(accessToken, locationIdList);
+      handleUpdateUserInfo();
+      navigate(LOCATION);
+    }
+  };
 
   useEffect(() => {
     setSearchResults(locationList);
@@ -49,9 +73,12 @@ export const LocationSetPage = () => {
       />
       <S.Main>
         <SearchBar searchTerm={searchTerm} setSearchTerm={setSearchTerm} />
-        <ul>
+        <ul onClick={(event) => handleAddLocation(event)}>
           {searchResults?.map((location: Location) => (
-            <S.location key={location.locationId}>
+            <S.location
+              key={location.locationId}
+              data-key={location.locationId}
+            >
               <span>{location.locationDetails}</span>
             </S.location>
           ))}

--- a/frontend/src/pages/LocationSet/styles.ts
+++ b/frontend/src/pages/LocationSet/styles.ts
@@ -13,4 +13,5 @@ export const location = styled.li`
   padding-top: 16px;
   padding-bottom: 16px;
   border-bottom: 1px solid rgba(179, 179, 179, 0.39);
+  cursor: pointer;
 `;


### PR DESCRIPTION
- 동네추가 클릭 시 동네 선택 리스트 페이지로 이동
- 검색으로 동네를 찾고 클릭하면 내 동네에 추가
- 동네 설정 페이지로 돌아가며 추가된 동네를 확인할 수 있다
- cloased : #142