### PR TITLE
FEAT: 상품등록에서 카테고리 페이지로 넘어가도 작성된 내용이 보존된다. (#177)

### DIFF
--- a/frontend/src/components/UploadComment/index.tsx
+++ b/frontend/src/components/UploadComment/index.tsx
@@ -27,7 +27,7 @@ const UploadComment = () => {
     // const rowCount = inputValue.split(/\r\n|\r|\n/).length;
     const newHeight = event.target.scrollHeight;
 
-    setTextareaValue(inputValue);
+    setTextareaValue(inputValue === '' ? null : inputValue);
 
     if (textareaValue !== null && textareaValue.length > inputValue.length) {
       setTextareaHeight(newHeight - 22);

--- a/frontend/src/context/SalesItem/useContext.tsx
+++ b/frontend/src/context/SalesItem/useContext.tsx
@@ -7,7 +7,7 @@ export interface PostObjectType {
   categoryId?: number | null;
   locationId?: number | null;
   memberId?: number | null;
-  files?: FormData[] | null;
+  files?: string[] | null;
 }
 
 export interface UploadPhotoType {


### PR DESCRIPTION
- 로컬스토리지 활용
- 로컬스토리지에서 가져온 데이터에 완료버튼 활성화 적용 추가

<img src="https://github.com/masters2023-2nd-project-03/second-hand/assets/109648042/e275fb3a-d1fe-40cf-bef9-57ec592af67e" width="50%" >
