### PR TITLE
FEAT : 상품상세 이미지 슬라이더 기능을 구현

### DIFF
--- a/frontend/src/components/DetailSliderPhotos/index.tsx
+++ b/frontend/src/components/DetailSliderPhotos/index.tsx
@@ -1,42 +1,48 @@
 import { useState } from 'react';
+
 import * as S from './styles';
 
 interface SecondHandItemProps {
   imageList: string[];
 }
 
+const IMAGE_TRANSLATE_RATIO = 100;
+
 const DetailSliderPhotos = ({ imageList }: SecondHandItemProps) => {
   const [imgIndex, setImgIndex] = useState<number>(0);
   const hasNext = imgIndex < imageList.length - 1;
-  // const translateX = -imgIndex * 100; // 이미지의 위치 계산
+  const hasPrev = imgIndex > 0;
+  const translateX = -imgIndex * IMAGE_TRANSLATE_RATIO;
 
   const handleImgNext = () => {
-    hasNext ? setImgIndex(imgIndex + 1) : setImgIndex(0);
+    hasNext ? setImgIndex(imgIndex + 1) : null;
   };
 
   const handleImgPrev = () => {
-    imgIndex > 0
-      ? setImgIndex(imgIndex - 1)
-      : setImgIndex(imageList.length - 1);
+    hasPrev ? setImgIndex(imgIndex - 1) : null;
   };
 
   return (
     <>
       <S.SliderContainer>
-        {/* <S.ImageContainer translateX={translateX}> */}
-        <S.SliderImage src={imageList[imgIndex]} />
-        {/* </S.ImageContainer> */}
-        <S.SliderTack>
-          <S.Button onClick={handleImgPrev}>＜</S.Button>
-          <S.ImgNavigate>
-            {imageList.map((_, index) => (
-              <S.Dot key={index} isActive={index === imgIndex}>
-                ●
-              </S.Dot>
-            ))}
-          </S.ImgNavigate>
-          <S.Button onClick={handleImgNext}>＞</S.Button>
-        </S.SliderTack>
+        <S.ImageTrack translateX={translateX} imageCount={imageList.length}>
+          {imageList.map((image, index) => (
+            <S.SliderImage key={index} src={image} />
+          ))}
+        </S.ImageTrack>
+        {imageList.length > 1 && (
+          <S.SliderTrack>
+            <S.Button onClick={handleImgPrev}>＜</S.Button>
+            <S.ImgNavigate>
+              {imageList.map((_, index) => (
+                <S.Dot key={index} isActive={index === imgIndex}>
+                  ●
+                </S.Dot>
+              ))}
+            </S.ImgNavigate>
+            <S.Button onClick={handleImgNext}>＞</S.Button>
+          </S.SliderTrack>
+        )}
       </S.SliderContainer>
     </>
   );

--- a/frontend/src/components/DetailSliderPhotos/index.tsx
+++ b/frontend/src/components/DetailSliderPhotos/index.tsx
@@ -1,16 +1,42 @@
+import { useState } from 'react';
 import * as S from './styles';
 
 interface SecondHandItemProps {
-  imageList: string;
+  imageList: string[];
 }
 
-// TODO : 아이템 이미지 리스트 다 가져오기
-
 const DetailSliderPhotos = ({ imageList }: SecondHandItemProps) => {
+  const [imgIndex, setImgIndex] = useState<number>(0);
+  const hasNext = imgIndex < imageList.length - 1;
+  // const translateX = -imgIndex * 100; // 이미지의 위치 계산
+
+  const handleImgNext = () => {
+    hasNext ? setImgIndex(imgIndex + 1) : setImgIndex(0);
+  };
+
+  const handleImgPrev = () => {
+    imgIndex > 0
+      ? setImgIndex(imgIndex - 1)
+      : setImgIndex(imageList.length - 1);
+  };
+
   return (
     <>
       <S.SliderContainer>
-        <S.SliderImage src={imageList} />
+        {/* <S.ImageContainer translateX={translateX}> */}
+        <S.SliderImage src={imageList[imgIndex]} />
+        {/* </S.ImageContainer> */}
+        <S.SliderTack>
+          <S.Button onClick={handleImgPrev}>＜</S.Button>
+          <S.ImgNavigate>
+            {imageList.map((_, index) => (
+              <S.Dot key={index} isActive={index === imgIndex}>
+                ●
+              </S.Dot>
+            ))}
+          </S.ImgNavigate>
+          <S.Button onClick={handleImgNext}>＞</S.Button>
+        </S.SliderTack>
       </S.SliderContainer>
     </>
   );

--- a/frontend/src/components/DetailSliderPhotos/styles.ts
+++ b/frontend/src/components/DetailSliderPhotos/styles.ts
@@ -2,11 +2,54 @@ import styled from 'styled-components';
 
 export const SliderContainer = styled.div`
   display: flex;
+  position: relative;
   height: 491px;
   width: 100%;
+`;
+
+// export const ImageContainer = styled.div<{ translateX: number }>`
+//   transform: translateX(${(props) => props.translateX}%);
+//   transition: transform 0.5s ease-in-out; // 트랜지션 효과 적용
+// `;
+
+export const SliderTack = styled.div`
+  position: absolute;
+  bottom: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+  width: 100%;
+  height: 44px;
+  display: flex;
+  justify-content: space-between;
+  padding: 0 16px 0 16px;
+  align-items: center;
 `;
 
 export const SliderImage = styled.img`
   width: 100%;
   object-fit: cover;
+`;
+
+export const Button = styled.button`
+  width: 44px;
+  height: 44px;
+  font-size: 24px;
+  ${({ theme }) => theme.color.neutralTextWeak}
+`;
+
+export const ImgNavigate = styled.div`
+  width: 44px;
+  height: 44px;
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  ${({ theme }) => theme.color.neutralTextWeak}
+`;
+
+export const Dot = styled.div<{ isActive: boolean }>`
+  ${({ isActive, theme }) =>
+    isActive
+      ? `${theme.color.neutralTextStrong}`
+      : `${theme.color.neutralTextWeak}`}
 `;

--- a/frontend/src/components/DetailSliderPhotos/styles.ts
+++ b/frontend/src/components/DetailSliderPhotos/styles.ts
@@ -3,16 +3,28 @@ import styled from 'styled-components';
 export const SliderContainer = styled.div`
   display: flex;
   position: relative;
-  height: 491px;
   width: 100%;
+  overflow-x: hidden;
 `;
 
-// export const ImageContainer = styled.div<{ translateX: number }>`
-//   transform: translateX(${(props) => props.translateX}%);
-//   transition: transform 0.5s ease-in-out; // 트랜지션 효과 적용
-// `;
+export const ImageTrack = styled.div<{
+  translateX: number;
+  imageCount: number;
+}>`
+  display: flex;
+  width: ${(props) => props.imageCount * 100}%;
+  transform: translateX(${(props) => props.translateX}%);
+  transition: transform 0.3s ease-in-out;
+`;
 
-export const SliderTack = styled.div`
+export const SliderImage = styled.img`
+  flex: 0 0 auto;
+  width: 100%;
+  height: 491px;
+  object-fit: cover;
+`;
+
+export const SliderTrack = styled.div`
   position: absolute;
   bottom: 0px;
   margin-left: 0px;
@@ -25,16 +37,12 @@ export const SliderTack = styled.div`
   align-items: center;
 `;
 
-export const SliderImage = styled.img`
-  width: 100%;
-  object-fit: cover;
-`;
-
 export const Button = styled.button`
   width: 44px;
   height: 44px;
   font-size: 24px;
   ${({ theme }) => theme.color.neutralTextWeak}
+  text-shadow: 0 0 3px rgba(255, 255, 255, 0.5);
 `;
 
 export const ImgNavigate = styled.div`
@@ -52,4 +60,6 @@ export const Dot = styled.div<{ isActive: boolean }>`
     isActive
       ? `${theme.color.neutralTextStrong}`
       : `${theme.color.neutralTextWeak}`}
+
+  text-shadow: 0 0 3px rgba(255, 255, 255, 0.5);
 `;

--- a/frontend/src/pages/ItemDetail/index.tsx
+++ b/frontend/src/pages/ItemDetail/index.tsx
@@ -89,7 +89,7 @@ const ItemDetail = () => {
         preTitleClick={handleBackIconClick}
       />
       {selectedItem && (
-        <DetailSliderPhotos imageList={selectedItem.imageList[0]} />
+        <DetailSliderPhotos imageList={selectedItem.imageList} />
       )}
       <S.Main>
         <S.SellerInfo>


### PR DESCRIPTION
상품 상세에서 이미지가 2장 이상인 경우 슬라이드로 넘어가는 기능을 구현했습니다.

- 처음 구상은 터치 슬라이더였지만, 웹에서의 동작 편의를 위해 버튼을 추가했습니다.
- 이미지가 한장 이라면 버튼과 네비는 나오지 않습니다.
- closed : #176 

![이미지 슬라이더](https://github.com/masters2023-2nd-project-03/second-hand/assets/109648042/1195adaa-ab58-40fb-bfd2-7557ae9959f2)
